### PR TITLE
Conditionally tunnel forego download through proxy

### DIFF
--- a/lib/download.js
+++ b/lib/download.js
@@ -2,15 +2,40 @@
 
 let fs      = require('fs');
 let https   = require('https');
+let url     = require('url');
+let cli     = require('heroku-cli-util');
+let tunnel  = require('tunnel-agent');
 
-function file (url, path, opts) {
+function file (urlStr, path, opts) {
   let tmpPath = path + '.tmp';
   return new Promise(function (fulfill, reject) {
-    https.get(url, function (res) {
+    let httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
+    var agent;
+    if (httpsProxy) {
+      cli.hush(`proxy set to ${httpsProxy}`);
+      let proxy = url.parse(httpsProxy);
+
+      agent = tunnel.httpsOverHttp({
+        proxy: {
+          host: proxy.hostname,
+          port: proxy.port || 8080
+        }
+      });
+    } else {
+      agent = new https.Agent();
+    }
+
+    let requestOptions = url.parse(urlStr);
+    requestOptions.agent = agent;
+
+    let req = https.request(requestOptions, function (res) {
       if (res.statusCode > 200 || res.statusCode >= 300) return reject(new Error(res.body));
       res.pipe(fs.createWriteStream(tmpPath, opts));
       res.on('end', fulfill);
     });
+    req.on('error', function(err) { reject(err); });
+    req.end();
+
   })
   .then(() => fs.renameSync(tmpPath, path));
 }

--- a/lib/download.js
+++ b/lib/download.js
@@ -10,7 +10,7 @@ function file (urlStr, path, opts) {
   let tmpPath = path + '.tmp';
   return new Promise(function (fulfill, reject) {
     let httpsProxy = process.env.HTTPS_PROXY || process.env.https_proxy;
-    var agent;
+    let agent;
     if (httpsProxy) {
       cli.hush(`proxy set to ${httpsProxy}`);
       let proxy = url.parse(httpsProxy);

--- a/lib/download.js
+++ b/lib/download.js
@@ -33,7 +33,7 @@ function file (urlStr, path, opts) {
       res.pipe(fs.createWriteStream(tmpPath, opts));
       res.on('end', fulfill);
     });
-    req.on('error', function(err) { reject(err); });
+    req.on('error', reject);
     req.end();
 
   })

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   ],
   "license": "ISC",
   "dependencies": {
-    "heroku-cli-util": "5.7.4"
+    "heroku-cli-util": "5.7.4",
+    "tunnel-agent": "^0.4.0"
   },
   "devDependencies": {
     "jshint": "^2.8.0"


### PR DESCRIPTION
I basically ported the https proxying code from the following places.  This cannot use the heroku client since it lives outside of api.heroku.com.  Since this is only used for one url that is known to be https, I kept it simple and just handle https_proxy.  Future work will include factoring this out into its own module, this is to quickly fix a support issue.

https://github.com/heroku/node-heroku-client/blob/master/lib/request.js#L39
https://github.com/heroku/heroku-cli-util/blob/master/lib/command.js#L43
