### PR TITLE
Excluding release from start unless explict

### DIFF
--- a/Procfile.test
+++ b/Procfile.test
@@ -1,3 +1,4 @@
 web: echo "it works (web)! port: $PORT"
 worker: echo "it works (worker)!"
+test: echo "it works (test)!"
 release: echo "it works (release)!"

--- a/circle.yml
+++ b/circle.yml
@@ -7,3 +7,4 @@ dependencies:
     - sudo add-apt-repository ppa:duggan/bats -y
     - sudo apt-get update
     - sudo apt-get install bats
+    - heroku plugins:link .

--- a/circle.yml
+++ b/circle.yml
@@ -7,4 +7,5 @@ dependencies:
     - sudo add-apt-repository ppa:duggan/bats -y
     - sudo apt-get update
     - sudo apt-get install bats
+    - npm install
     - heroku plugins:link .

--- a/commands/start.js
+++ b/commands/start.js
@@ -12,7 +12,14 @@ function * run (context) {
   if (context.flags.procfile) process.argv.push('--procfile', context.flags.procfile)
   if (context.flags.env) process.argv.push('--env', context.flags.env)
   if (context.flags.port) process.argv.push('--port', context.flags.port)
-  if (context.args.processname) process.argv.push(context.args.processname)
+  if (context.args.processname) {
+    process.argv.push(context.args.processname)
+  } else {
+    let procfile = context.flags.procfile || 'Procfile'
+    let procHash = require('foreman/lib/procfile.js').loadProc(procfile)
+    let processes = Object.keys(procHash).filter((x) => x !== 'release')
+    process.argv.push(processes.join(','))
+  }
 
   require('foreman/nf.js')
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "url": "https://github.com/heroku/heroku-local/issues"
   },
   "dependencies": {
+    "co": "4.6.0",
     "foreman": "2.0.0-1",
     "heroku-cli-util": "6.0.11"
   },

--- a/test/start.bats
+++ b/test/start.bats
@@ -10,3 +10,24 @@ setup() {
   [ "$status" -eq 0 ]
   [[ "$output" =~ "it works (web)!" ]]
 }
+
+@test "start includes just web & worker" {
+  run heroku local
+  echo $output
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "it works (web)!" ]] && [[ "$output" =~ "it works (worker)!" ]] && [[ ! "$output" =~ "it works (release)!" ]]
+}
+
+@test "start -f Procfile.test includes just web & worker & test" {
+  run heroku local -f Procfile.test
+  echo $output
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "it works (web)!" ]] && [[ "$output" =~ "it works (worker)!" ]] && [[ "$output" =~ "it works (test)!" ]] && [[ ! "$output" =~ "it works (release)!" ]]
+}
+
+@test "start release includes release" {
+  run heroku local release
+  echo $output
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ "it works (release)!" ]]
+}


### PR DESCRIPTION
@dickeyxxx @dmathieu review me?  basically what I did was use the node forman libraries to parse the procfile and then manually pass the list with release excluded.

> We have a small issue with release-phase. We request customers to add their release command to their Procfile.  That means `heroku local` will run the release process type by default, which isn't meant to be a long-running one.
> We would like to not run that process type by default with that command.  I've been digging around heroku-local, and it seems we don't have direct control over that. The foreman-npm dependency decides which processes to run.
> Have we considered forking that dependency? Would you see a better solution to achieve that?
