### PR TITLE
fix: expose as a binary

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 'use strict'
 
 const flatten = require('lodash.flatten')

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "bugs": {
     "url": "https://github.com/heroku/heroku-local/issues"
   },
+  "bin": {
+    "heroku": "index.js"
+  },
   "dependencies": {
     "@heroku/foreman": "^2.0.2",
     "co": "^4.6.0",


### PR DESCRIPTION
when I install this module globally, it's not available as `heroku`

This PR fix that 